### PR TITLE
Added support for docker compose to spin up unittests dependencies

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,15 @@
 version: "3.9"
+networks:
+  dependencies:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
 services:
   modelbox:
-    image: diptanu/modelbox:0.0.1-next-arm64v8 
+    image: diptanu/modelbox:0.0.1-next-amd64
+    profiles:
+      - local
     command: [ "server", "start", "--config-path=/app/config/modelbox.toml" ]
     volumes:
       - type: volume
@@ -10,5 +18,39 @@ services:
       - type: bind
         source: ./server/config
         target: "/app/config" # binds config file
+  postgres:
+    image: postgres
+    profiles:
+      - local
+      - unittests
+    restart: always
+    environment:
+      - POSTGRES_PASSWORD=foo
+    networks:
+        dependencies:
+            ipv4_address: 172.20.0.5
+  mysql:
+    image: mysql
+    profiles:
+      - local
+      - unittests
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    networks:
+        dependencies:
+            ipv4_address: 172.20.0.6
+    environment:
+      - MYSQL_ROOT_PASSWORD=foo
+  timescaledb:
+    image: timescale/timescaledb:latest-pg14
+    profiles:
+      - local
+      - unittests
+    restart: always
+    networks:
+        dependencies:
+            ipv4_address: 172.20.0.7
+    environment:
+      - POSTGRES_PASSWORD=foo
 volumes:
   data:

--- a/server/storage/logging/timescaledb_test.go
+++ b/server/storage/logging/timescaledb_test.go
@@ -58,7 +58,7 @@ func TestPostgresTestSuite(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	port, _ := strconv.ParseUint(env("POSTGRES_TEST_PORT", "5432"), 10, 64)
 	config := TimescaleDbConfig{
-		Host:     env("POSTGRES_TEST_HOST", "172.17.0.4"),
+		Host:     env("POSTGRES_TEST_HOST", "172.20.0.7"),
 		Port:     int(port),
 		UserName: env("POSTGRES_TEST_USER", "postgres"),
 		Password: env("POSTGRES_TEST_PASS", "foo"),

--- a/server/storage/mysql_test.go
+++ b/server/storage/mysql_test.go
@@ -30,7 +30,7 @@ func init() {
 	user = env("MYSQL_TEST_USER", "root")
 	pass = env("MYSQL_TEST_PASS", "foo")
 	prot = env("MYSQL_TEST_PROT", "tcp")
-	host = env("MYSQL_TEST_HOST", "172.17.0.2")
+	host = env("MYSQL_TEST_HOST", "172.20.0.6")
 	dbname = env("MYSQL_TEST_DBNAME", "gotest")
 }
 

--- a/server/storage/postgres_test.go
+++ b/server/storage/postgres_test.go
@@ -38,7 +38,7 @@ func TestPostgresTestSuite(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	port, _ = strconv.ParseUint(env("POSTGRES_TEST_PORT", "5432"), 10, 64)
 	config := PostgresConfig{
-		Host:     env("POSTGRES_TEST_HOST", "172.17.0.3"),
+		Host:     env("POSTGRES_TEST_HOST", "172.20.0.5"),
 		Port:     int(port),
 		UserName: env("POSTGRES_TEST_USER", "postgres"),
 		Password: env("POSTGRES_TEST_PASS", "foo"),


### PR DESCRIPTION
### Start Docker compose 
docker compose --profile unittests  up -d

### Run Unit Tests 
```
(base) diptanuc@firefly:~/Projects/modelbox$ go test ./server/storage/...
ok      github.com/tensorland/modelbox/server/storage   (cached)
?       github.com/tensorland/modelbox/server/storage/artifacts [no test files]
ok      github.com/tensorland/modelbox/server/storage/logging   (cached)
```

### Stop Compose 
docker compose --profile unittests down